### PR TITLE
Pere encoders

### DIFF
--- a/feature_extractors.py
+++ b/feature_extractors.py
@@ -1,6 +1,6 @@
 ## In this file few feature extraction functions are defined. Such functions don't have input arguments
 #  and return a Composition of transforms to be applied to the database as well as a feature extraction module.
-#  The feature extraction module, given an input of a tensor with a badge of images, returns a batch of tensors of dimesion (bsz,num_feat,L) where L are the number 
+#  The feature extraction module, given as input a tensor with a badge of cropped and normalized RGB images, returns a batch of tensors of dimesion (bsz,num_feat,L) where L are the number 
 #  of embeddings of the image (each one roughly corresponding to a patch of the image) 
 
 ## Ojo, que mejor se debería hacer uns tranpose de los tensores de salida. Eso segun se haya definido el attention y el decoder.

--- a/feature_extractors.py
+++ b/feature_extractors.py
@@ -1,14 +1,13 @@
-# In this file the class Encoder defined. The class is an nn module that implements feature extraction from images by means of 
+# In this file the class Encoder is defined. The class is an nn module that implements feature extraction from images by means of 
 # the convolutional base of a pre-trained VGG-16 Neural Network. 
 # The feature extraction module, given as input a tensor with a badge of cropped and normalized RGB images, returns a batch of tensors of 
 # dimesion (bsz,L,num_feat) where L are the number of embeddings of the image (each one roughly corresponding to a patch of the image)
 #  
 # The argument num_emb of the constructor defines the number embeddings that will be extracted from the image. It can only take only the values 49 or 196.
 # Default value is 196.    
-#    
 # 
-## Ojo, que mejor se debería hacer uns transpose de los tensores de salida. Eso segun se haya definido el attention y el decoder.
-## De momento no incluyo el tema de las transformadas.
+# The parameters of the encoder are frozen. In case of the need of fine tuning, the lastest layers of the network should be unfrozen.   
+# 
 #   Example for using for inference:
 #   encoder = Encoder(num_emb_196=True)
 #	encoder.eval()      
@@ -17,135 +16,94 @@
 #          param.requires_grad = False
 #
 
+import torch
 import torchvision.transforms as transforms
 import torchvision.models as models
 import torch.nn as nn
 
+## Import per fer proves
+
+from dataset import Flickr8kDataset
+from torch.utils.data import Dataset, DataLoader
+from caps_collate import CapsCollate
 
 class Encoder(nn.Module):
 
     def __init__(self,num_emb_196=True):
         super().__init__()
 
+    ####   If we wanted to use the resnet50
+    #   resnet = models.resnet50(pretrained=True)
+    #   modules = list(resnet.children())[:-2]
+    #   self.resnet = nn.Sequential(*modules)
+
+   #####    We use a vgg16 network for the  feature extraction
         pretrained_model = models.vgg16(pretrained=True)
-        if num_emb_196==True:
-            self.conv_base = pretrained_model.features
+        if num_emb_196==True:                                   # In this case we just keep the first 24 layers of the Vgg
+            self.conv_base = nn.Sequential(*list(pretrained_model.features)[0:24])
             print("Extracting 196 feat vect from the image")
         else:
-            self.conv_base = nn.Sequential(*list(pretrained_model.features)[0:24])
+            self.conv_base = pretrained_model.features         # In this case we keep all the layers of the convolutional base of the Vgg
             print("Extracting 49 feat vect from the image")
 
-        self.flat = nn.Flatten(2,3)
+    # Freeze All layers as it will be mainly used for inference
+
+        for i,param in enumerate(self.conv_base.parameters()):  
+            param.requires_grad = False
+        #    print(param.name, param.requires_grad)
+        # print("numero de grupos de parametros:", i+1)
+
+     # Flaten layer that flatten the dimensions 2 and 3 (H and W of the feature maps respectively)
+        self.flat = nn.Flatten(2,3)      ####   MAYBE BETTER USE RESHAPE ???
 
     def forward(self, x):
-        x = self.conv_base(x)
-        x = self.flat(x)
-        y =  x.transpose(1,2)
-        return y
-
-    # Obtain the parameters of the tensor in terms of:
-    # 1) batch size
-    # 2) number of channels
-    # 3) spatial "height"
-    # 4) spatial "width"
-#        bsz, nch, height, width = x.shape
-
-    # Flatten the feature map with the view() operator 
-    # within each batch sample
-
-    #    x = x.view(bsz,-1)
-    #    y = self.mlp(x)    # No sé perquè aquí fa servir la y enlloc de la x? Passaria algo???
-    #    return y
+        feat = self.conv_base(x)          # (batch_size, feat_maps=512, H=7 , W=7) or (batch_size, 512, 14 , 14)
+        feat = self.flat(feat)               # (batch_size, 512, 7x7=49) or (batch_size, 512, 14x14=196)
+        feat =  feat.transpose(1,2)          # (batch_size, 49, 512) or (batch_size, 196, 512)
+        return feat
 
 
+if __name__ == "__main__":
 
-
-def get_feat_extractor_Vgg_L49():
-    """
-    This function returns a Composition of transforms to be applied to the images of the database, and 
-    a feature extraction module which is the convolutional base of a VGG-16 Neural Network and can be used as encoder.
-    The feature extraction module needs at its input a tensor with a badge of 224x224 cropped RGB images normalized with the Imagenet 
-    parameters. Input tensor dimensions (bsz,3,224,224). And gives as output a tensor with a badge of L vectors of features (embeddings), each vector 
-    roughly corresponding to the embedding of a patch of the image. Dimesion: (bsz,num_feat=512,L=49)
-    The feature extraction model has all its layers frozen.
-    Example:
-    transf, encoder = get_feat_extractor_Vgg_L49()
-	encoder.eval()      
-    encoder.to(device)
-    """
-
-## Aquests funció retorna la tranformació que s'ha d'aplicar a la base de dades i un modul amb la part convolucuinal de una pretrained_VGG més un flatten per aconseguir 49 vectores (7x7) de 512 feaures cadascun
-# El model té les capes congelades ja que està pensat inicialment per a inferència. 
-# La transformació conté una normalització amb valors de Imagenet ja que la pretrained VGG estava entrenada amb Imagenet.
-
-    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],std=[0.229, 0.224, 0.225])
-    trans = transforms.Compose([
-                           transforms.Resize(224),
-                           transforms.CenterCrop(224),
-                           transforms.ToTensor(),
-                           normalize,
+    num_emb_196=False     ## If this is false the number of embeddings per image is 49
+    image_size = 224   ## this is to keep the aspect relation. Otherwised we could set image_size to (224,224) and then there is no need to crop the image.
+    batch_size = 16
+    MAX_SIZE = 5000
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Resize(image_size),
+        transforms.CenterCrop(image_size),   ## only meaningful when we are keeping the aspect ratio when resizing. Otherwhise it has no effect
+        # The normalize parameters depends on the model we're gonna use
+        # If we apply transfer learning from a model that used ImageNet, then
+        # we should use the ImageNet values to normalize the dataset.
+        # Otherwise we could just normalize the values between -1 and 1 using the 
+        # standard mean and standard deviation
+        transforms.Normalize(mean=[0.485, 0.456, 0.406],std=[0.229, 0.224, 0.225]),
+        #transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
     ])
+    dataset = Flickr8kDataset(transform=transform,reduce=True,max_size=MAX_SIZE)
 
-    pretrained_model = models.vgg16(pretrained=True)
+    # split the database    TODO
+    # print(len(dataset))
 
-    feat_extractor = nn.Sequential(pretrained_model.features,nn.Flatten(2,3))
+    # Set up the data loader for test
+    dataloader = DataLoader(dataset=dataset,batch_size=batch_size, collate_fn=CapsCollate(pad_idx=dataset.vocab.word_to_index['<PAD>'],batch_first=True))
+    batch_sample = next(iter(dataloader))
+    images, captions = batch_sample
 
+    # Load the encoder
+    encoder = Encoder(num_emb_196=False)
+    encoder.eval()
 
-    for layer in feat_extractor[:]:  # Freeze All layers 
-        for param in layer.parameters():
-            param.requires_grad = False
+##    encoder.to(device)
 
-#for layer in feature_extractor[24:]:  # Train layers 24 to 30
-#    for param in layer.parameters():
-#        param.requires_grad = True
-    return trans, feat_extractor
+    print(encoder) 
 
+    print("Shape of the images tensor:",images.shape)
 
+    img_emb = encoder(images)
 
+    print("Shape of the extracted features:",img_emb.shape)
 
-#feature_extractor = nn.Sequential(modelAux[0], modelAux[1], modelAux[2])
-#feature_extractor = nn.Sequential(modelAux[0:31])
-#feature_extractor = nn.Sequential(*list(modelAux)[0:23])
-
-def get_feat_extractor_Vgg_L196():
-
-    """
-    This function returns a Composition of transforms to be applied to the images of the database, and 
-    a feature extraction module which is the convolutional base of a VGG-16 Neural Network trunked a given layer, and can be used as encoder.
-    The feature extraction module needs at its input a tensor with a badge of 224x224 cropped RGB images normalized with the Imagenet 
-    parameters. Input tensor dimensions (bsz,3,224,224). And gives as output a tensor with a badge of L vectors of features (embeddings), each vector 
-    roughly corresponding to the embedding of a patch of the image. Dimesion: (bsz,num_feat=512,L=196)
-    The feature extraction model has all its layers frozen.
-    Example:
-    transf, encoder = get_feat_extractor_Vgg_L196()
-    """
-## Aquests funció retorna la tranformació que s'ha d'aplicar a la base de dades i un modul amb la part convolucuinal de una pretrained_VGG més un flatten per aconseguir 49 vectores (7x7) de 512 feaures cadascun
-# El model té les capes congelades ja que està pensat inicialment per a inferència. 
-# La transformació conté una normalització amb valors de Imagenet ja que la pretrained VGG estava entrenada amb Imagenet.
-
-    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],std=[0.229, 0.224, 0.225])
-    trans = transforms.Compose([
-                           transforms.Resize(224),
-                           transforms.CenterCrop(224),
-                           transforms.ToTensor(),
-                           normalize,
-    ])
-
-    pretrained_model = models.vgg16(pretrained=True)
-
-    #feature_extractor = nn.Sequential(modelAux[0], modelAux[1], modelAux[2])
-    modelAux = pretrained_model.features
-    modelAux = nn.Sequential(*list(modelAux)[0:24])
-
-    feat_extractor = nn.Sequential(modelAux,nn.Flatten(2,3))
-
-
-    for layer in feat_extractor[:]:  # Freeze All layers 
-        for param in layer.parameters():
-            param.requires_grad = False
-
-#for layer in feature_extractor[24:]:  # Train layers 24 to 30
-#    for param in layer.parameters():
-#        param.requires_grad = True
-    return trans, feat_extractor
-
+    # print an example of some items of the features tensor
+    print(img_emb[0][0][:14])

--- a/feature_extractors.py
+++ b/feature_extractors.py
@@ -1,0 +1,101 @@
+## In this file few feature extraction functions are defined. Such functions don't have input arguments
+#  and return a Composition of transforms to be applied to the database as well as a feature extraction module.
+#  The feature extraction module, given an input of a tensor with a badge of images, returns a batch of tensors of dimesion (bsz,num_feat,L) where L are the number 
+#  of embeddings of the image (each one roughly corresponding to a patch of the image) 
+
+## Ojo, que mejor se debería hacer uns tranpose de los tensores de salida. Eso segun se haya definido el attention y el decoder.
+
+
+import torchvision.transforms as transforms
+import torchvision.models as models
+import torch.nn as nn
+
+def get_feat_extractor_Vgg_L49():
+    """
+    This function returns a Composition of transforms to be applied to the images of the database, and 
+    a feature extraction module which is the convolutional base of a VGG-16 Neural Network and can be used as encoder.
+    The feature extraction module needs at its input a tensor with a badge of 224x224 cropped RGB images normalized with the Imagenet 
+    parameters. Input tensor dimensions (bsz,3,224,224). And gives as output a tensor with a badge of L vectors of features (embeddings), each vector 
+    roughly corresponding to the embedding of a patch of the image. Dimesion: (bsz,num_feat=512,L=49)
+    The feature extraction model has all its layers frozen.
+    Example:
+    transf, encoder = get_feat_extractor_Vgg_L49()
+	encoder.eval()      
+    encoder.to(device)
+    """
+
+## Aquests funció retorna la tranformació que s'ha d'aplicar a la base de dades i un modul amb la part convolucuinal de una pretrained_VGG més un flatten per aconseguir 49 vectores (7x7) de 512 feaures cadascun
+# El model té les capes congelades ja que està pensat inicialment per a inferència. 
+# La transformació conté una normalització amb valors de Imagenet ja que la pretrained VGG estava entrenada amb Imagenet.
+
+    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],std=[0.229, 0.224, 0.225])
+    trans = transforms.Compose([
+                           transforms.Resize(224),
+                           transforms.CenterCrop(224),
+                           transforms.ToTensor(),
+                           normalize,
+    ])
+
+    pretrained_model = models.vgg16(pretrained=True)
+
+    feat_extractor = nn.Sequential(pretrained_model.features,nn.Flatten(2,3))
+
+
+    for layer in feat_extractor[:]:  # Freeze All layers 
+        for param in layer.parameters():
+            param.requires_grad = False
+
+#for layer in feature_extractor[24:]:  # Train layers 24 to 30
+#    for param in layer.parameters():
+#        param.requires_grad = True
+    return trans, feat_extractor
+
+
+
+
+#feature_extractor = nn.Sequential(modelAux[0], modelAux[1], modelAux[2])
+#feature_extractor = nn.Sequential(modelAux[0:31])
+#feature_extractor = nn.Sequential(*list(modelAux)[0:23])
+
+def get_feat_extractor_Vgg_L196():
+
+    """
+    This function returns a Composition of transforms to be applied to the images of the database, and 
+    a feature extraction module which is the convolutional base of a VGG-16 Neural Network trunked a given layer, and can be used as encoder.
+    The feature extraction module needs at its input a tensor with a badge of 224x224 cropped RGB images normalized with the Imagenet 
+    parameters. Input tensor dimensions (bsz,3,224,224). And gives as output a tensor with a badge of L vectors of features (embeddings), each vector 
+    roughly corresponding to the embedding of a patch of the image. Dimesion: (bsz,num_feat=512,L=196)
+    The feature extraction model has all its layers frozen.
+    Example:
+    transf, encoder = get_feat_extractor_Vgg_L196()
+    """
+## Aquests funció retorna la tranformació que s'ha d'aplicar a la base de dades i un modul amb la part convolucuinal de una pretrained_VGG més un flatten per aconseguir 49 vectores (7x7) de 512 feaures cadascun
+# El model té les capes congelades ja que està pensat inicialment per a inferència. 
+# La transformació conté una normalització amb valors de Imagenet ja que la pretrained VGG estava entrenada amb Imagenet.
+
+    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],std=[0.229, 0.224, 0.225])
+    trans = transforms.Compose([
+                           transforms.Resize(224),
+                           transforms.CenterCrop(224),
+                           transforms.ToTensor(),
+                           normalize,
+    ])
+
+    pretrained_model = models.vgg16(pretrained=True)
+
+    #feature_extractor = nn.Sequential(modelAux[0], modelAux[1], modelAux[2])
+    modelAux = pretrained_model.features
+    modelAux = nn.Sequential(*list(modelAux)[0:24])
+
+    feat_extractor = nn.Sequential(modelAux,nn.Flatten(2,3))
+
+
+    for layer in feat_extractor[:]:  # Freeze All layers 
+        for param in layer.parameters():
+            param.requires_grad = False
+
+#for layer in feature_extractor[24:]:  # Train layers 24 to 30
+#    for param in layer.parameters():
+#        param.requires_grad = True
+    return trans, feat_extractor
+


### PR DESCRIPTION
I added a file named feature_extractors.py that contain definitions of few functions that create and return an encoder that is based on a  pretrained  VGG-16 convolutional network. Such functions also returns a Composition of transforms that can be applied to the Pil Images before they are input to the encoder.
The functions differ in the number of feature vectors that they create from the image. Two versions: 49 vectors and 196 vectors per image.